### PR TITLE
Infinite scroll summary fix

### DIFF
--- a/app/reducers/reducers.js
+++ b/app/reducers/reducers.js
@@ -34,7 +34,8 @@ export const articleList = (state = { "articles":new ArticleList([]), "stream": 
       return ms
     case actionTypes.SHOW_STREAM:
       let stream = state.stream.clone()
-      stream.append(action.articles)
+      let added = new ArticleList(action.articles)
+      stream.append(added.articles)
       //return all of the articles
       return Object.assign({}, state, {
         stream:  stream

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curator",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "React version of biaschecker.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The summaries were showing as Processing... This is an interstitial status when we are initially adding an article, and should not be showing for old articles.